### PR TITLE
fix: add templateString property in function compilation errors

### DIFF
--- a/packages/template/index.js
+++ b/packages/template/index.js
@@ -119,10 +119,16 @@ module.exports = function template(templateString, templateVariables, ut = {}, e
     }
 
     let templateFunction;
-    if (vm.compileFunction) {
-        templateFunction = vm.compileFunction(functionBody, keys);
-    } else {
-        templateFunction = new Function(...keys, functionBody); // eslint-disable-line
+    try {
+        if (vm.compileFunction) {
+            templateFunction = vm.compileFunction(functionBody, keys);
+        } else {
+            templateFunction = new Function(...keys, functionBody); // eslint-disable-line
+        }
+    } catch (e) {
+        e.templateString = templateString;
+        throw e;
     }
+
     return array ? (...params) => templateFunction(ut, ...params) : templateFunction(...values);
 };

--- a/packages/template/index.test.js
+++ b/packages/template/index.test.js
@@ -87,5 +87,7 @@ tap.test('render', assert => {
         multiply: (x, y) => x * y
     }), {deep: true}), 'recursive object values rendering');
 
+    assert.throws(() => template('${', {}), {templateString: '${'}, 'Unexpected end of input');
+
     assert.end();
 });


### PR DESCRIPTION
add templateString property in function compilation errors